### PR TITLE
Added information to package so it will show on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wysiwyg",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "enable limited interaction with a content editable element, useful for in-place, wysiwyg editing",
   "main": "index.js",
   "scripts": {},
@@ -15,6 +15,14 @@
   },
   "author": "Ben McMahen",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bmcmahen/react-wysiwyg.git"
+  },  
+  "bugs": {
+    "url": "https://github.com/bmcmahen/react-wysiwyg/issues"
+  },
+  "homepage": "https://github.com/bmcmahen/react-wysiwyg/",
   "devDependencies": {
     "browserify": "^8.1.1",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
When finding the module on NPM it didn't show any repo information, so I added the information into the package.json and bumped the version so next time it is published those details will show on npm.
