### PR TITLE
Added option to run onEnterKey function even if textfield is not empt…

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -22,6 +22,8 @@ var Example = React.createClass({
           autoFocus={true}
           maxLength={200}
           onChange={this.onChange}
+          onEnterKey={this.onEnterKey}
+          saveOnEnterKey={true}
           editing={this.state.editing}
         />
         <button onClick={this.enableEditing}>
@@ -40,6 +42,11 @@ var Example = React.createClass({
 
   enableEditing: function(){
     // set your contenteditable field into editing mode.
+    this.setState({ editing: !this.state.editing });
+  },
+
+  onEnterKey: function(text){
+    alert("You pressed enter! Saving: "+text);
     this.setState({ editing: !this.state.editing });
   }
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ var ContentEditable = React.createClass({
     tagName: React.PropTypes.string,
     autoFocus: React.PropTypes.bool,
     onEnterKey: React.PropTypes.func,
-    onEscapeKey: React.PropTypes.func
+    onEscapeKey: React.PropTypes.func,
+    saveOnEnterKey: React.PropTypes.bool
   },
 
   getDefaultProps: function() {
@@ -150,7 +151,16 @@ var ContentEditable = React.createClass({
 
       var keyCode = e.keyCode;
 
-      // 'Bold' and 'Italic' text using keyboard
+      var saveOnEnterKey = this.props.saveOnEnterKey || false;
+
+      if(saveOnEnterKey && keyCode === 13){
+        var text = e.target.textContent;
+        this.props.onEnterKey(text);
+        return;
+      }
+
+
+    // 'Bold' and 'Italic' text using keyboard
       if (e.metaKey) {
           // ⌘ 'b' or ⌘'i' in Mac for bold/italic
           if (keyCode === 66 || keyCode === 73) {


### PR DESCRIPTION
I needed the possibility to save (i.e run onEnterKey) when you press 'enter' **and the textfield is not empty**.

New prop: saveOnEnterKey=[true | false]

If there is another way to achieve this functionality please disregard this pull request. (And I would be interested to know how. :) )
