### PR TITLE
Fix typo in ContentEditable#getInitalState

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var ContentEditable = React.createClass({
     };
   },
 
-  getInitalState: function(){
+  getInitialState: function(){
     return {};
   },
 


### PR DESCRIPTION
Change misspelled ContentEditable#getInitalState method to ContentEditable#getInitialState.
