### PR TITLE
Option to add style via a prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ var ContentEditable = React.createClass({
       onMouseDown: this.onMouseDown,
       'aria-label': this.props.placeholderText,
       onTouchStart: this.onMouseDown,
-      style: this.props.placeholder ? placeholderStyle : {},
+      style: this.props.placeholder ? placeholderStyle : this.props.style || {},
       onKeyPress: this.onKeyPress,
       onInput: this.onInput,
       onKeyUp: this.onKeyUp,


### PR DESCRIPTION
Not sure if it was intentional that everything should be done via placeholder. Let me know if I'm missing something.

This adds the ability to style your `contentEditable` through `style` prop.

By the way - awesome lib :heart: 
