### PR TITLE
Make paste behavior mirror the behavior browsers typically exhibit.

### DIFF
--- a/__tests__/factories.js
+++ b/__tests__/factories.js
@@ -4,7 +4,7 @@ var Test = React.addons.TestUtils
 var Edit = require('../')
 
 module.exports = {
-  editor(args = {}) {
+  editorElement(args) {
     let props = _.assign({
       editing: true,
       html: 'hi',
@@ -13,6 +13,10 @@ module.exports = {
       placeholderText: 'placeholder'
     }, args)
 
-    return Test.renderIntoDocument(<Edit {...props} />)
+    return <Edit {...props} />
+  },
+
+  editor(args = {}) {
+    return Test.renderIntoDocument(this.editorElement(args))
   }
 };

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -4,7 +4,7 @@ var Test = React.addons.TestUtils
 var expect = require('expect')
 var Factory = require('./factories');
 
-describe('Editable', () => {
+describe('Editable', function() {
 
   function getEl(component) {
     return React.findDOMNode(component)
@@ -212,4 +212,80 @@ describe('Editable', () => {
     }, 10)
   })
 
+  describe('pasting based on cursor position', () => {
+    beforeEach(() => {
+      // focus and cursor selection require dom nodes that are attached to the document.
+      this.container = document.createElement('div')
+      document.body.appendChild(this.container)
+    })
+
+    afterEach(() => {
+      React.unmountComponentAtNode(this.container);
+      document.body.removeChild(this.container)
+    })
+
+    function setCurrentRange(range) {
+      let selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    function charactersBeforeRange(range) {
+      return Array.prototype.slice.call(range.startContainer.childNodes, 0, range.startOffset)
+        .map((node) => node.textContent)
+        .join('')
+    }
+
+    it('should paste at the cursor', (next) => {
+      let reactElement = Factory.editorElement({
+        editing: true,
+        html: 'hi john',
+        placeholder: false,
+        onChange: function(v, setplaceholder, html) {
+          expect(v).toEqual('hi merry john');
+          var selection = window.getSelection();
+          var range = selection.getRangeAt(0);
+          expect(range.startContainer).toEqual(range.endContainer);
+          expect(range.startOffset).toEqual(range.endOffset);
+          expect(charactersBeforeRange(range)).toEqual('hi merry');
+          next();
+        }
+      })
+      let c = React.render(reactElement, this.container);
+
+      let el = getEl(c)
+      let range = document.createRange();
+      range.setStart(el.childNodes[0], 2);
+      range.collapse(true);
+      setCurrentRange(range);
+
+      Test.Simulate.paste(el, { clipboardData: { getData: () => ' merry' } })
+    })
+
+    it('should replace selection when pasting', (next) => {
+      let reactElement = Factory.editorElement({
+        editing: true,
+        html: 'dab',
+        placeholder: false,
+        onChange: function(v, setplaceholder, html) {
+          expect(v).toEqual('doorknob');
+          var selection = window.getSelection();
+          var range = selection.getRangeAt(0);
+          expect(range.startContainer).toEqual(range.endContainer);
+          expect(range.startOffset).toEqual(range.endOffset);
+          expect(charactersBeforeRange(range)).toEqual('doorkno');
+          next();
+        }
+      })
+      let c = React.render(reactElement, this.container);
+
+      let el = getEl(c)
+      let range = document.createRange();
+      range.setStart(el.childNodes[0], 1);
+      range.setEnd(el.childNodes[0], 2);
+      setCurrentRange(range);
+
+      Test.Simulate.paste(el, { clipboardData: { getData: () => 'oorkno' } })
+    })
+  })
 })

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -242,12 +242,12 @@ describe('Editable', function() {
         html: 'hi john',
         placeholder: false,
         onChange: function(v, setplaceholder, html) {
-          expect(v).toEqual('hi merry john');
+          expect(v).toEqual('hi <em>merry</em> john');
           var selection = window.getSelection();
           var range = selection.getRangeAt(0);
           expect(range.startContainer).toEqual(range.endContainer);
           expect(range.startOffset).toEqual(range.endOffset);
-          expect(charactersBeforeRange(range)).toEqual('hi merry');
+          expect(charactersBeforeRange(range)).toEqual('hi <em>merry</em>');
           next();
         }
       })
@@ -259,7 +259,7 @@ describe('Editable', function() {
       range.collapse(true);
       setCurrentRange(range);
 
-      Test.Simulate.paste(el, { clipboardData: { getData: () => ' merry' } })
+      Test.Simulate.paste(el, { clipboardData: { getData: () => ' <em>merry</em>' } })
     })
 
     it('should replace selection when pasting', (next) => {

--- a/index.js
+++ b/index.js
@@ -266,7 +266,8 @@ var ContentEditable = React.createClass({
     var selection = window.getSelection();
     var range = selection.getRangeAt(0);
     range.deleteContents();
-    var fragment = range.createContextualFragment(data)
+    var fragment = range.createContextualFragment('');
+    fragment.textContent = data;
     var replacementEnd = fragment.lastChild;
     range.insertNode(fragment);
     // Set cursor at the end of the replaced content, just like browsers do.

--- a/index.js
+++ b/index.js
@@ -155,17 +155,6 @@ var ContentEditable = React.createClass({
     sel.addRange(range);
   },
 
-  setCursorToEnd: function() {
-    var el = React.findDOMNode(this)
-    el.focus()
-    var range = document.createRange()
-    range.selectNodeContents(el)
-    range.collapse(false)
-    var sel = window.getSelection()
-    sel.removeAllRanges()
-    sel.addRange(range)
-  },
-
   contentIsEmpty: function (content) {
 
     if (this.state.placeholder) {
@@ -273,16 +262,27 @@ var ContentEditable = React.createClass({
     }
   },
 
+  _replaceCurrentSelection: function(data) {
+    var selection = window.getSelection();
+    var range = selection.getRangeAt(0);
+    range.deleteContents();
+    var fragment = range.createContextualFragment(data)
+    var replacementEnd = fragment.lastChild;
+    range.insertNode(fragment);
+    // Set cursor at the end of the replaced content, just like browsers do.
+    range.setStartAfter(replacementEnd);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  },
+
   onPaste: function(e){
     // handle paste manually to ensure we unset our placeholder
     e.preventDefault();
     var data = e.clipboardData.getData('text/plain')
-    this.props.onChange(escapeHTML(data), false, data)
-    // a bit hacky. set cursor to end of contents
-    // after the paste, which is async
-    setTimeout(function(){
-      this.setCursorToEnd()
-    }.bind(this), 0)
+    this._replaceCurrentSelection(data);
+    var target = React.findDOMNode(this)
+    this.props.onChange(target.textContent, false, target.innerHTML)
   },
 
   onKeyPress: function(e){


### PR DESCRIPTION
This PR implements the typical behavior for pasting into a textarea or input text box. It's a considerable departure from the current implementation, but it is well-tested and (I'd claim) more intuitive than the current behavior.
![paste-demo](https://cloud.githubusercontent.com/assets/1276728/10265287/92a616a8-69df-11e5-8cf3-59038e998a88.gif)

This implementation follows the following rules:
1. When a paste occurs with no selection (more explicitly represented as a selection of range 0), the paste content is inserted at the cursor position and the cursor position is set to the end of the pasted content.
2. When a paste occurs with a selection, we delete the selected content and then do case 1.
#### Open questions:
- should the input accept plain text like it does now, or should it insert HTML that is pasted to preserve the formatting of the content?
  - are there security concerns in inserting pasted HTML?
  - Should parsing/rendering pasted HTML be an option?
- [ ] Might not work when textarea has no content.
