### PR TITLE
Allow paste on Mac when there is not content.   

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,9 @@ var ContentEditable = React.createClass({
         if (this.props.preventStyling) {
           return prev()
         }
+      //paste
+      } else if (key === 86) {
+        return;
       }
     }
 


### PR DESCRIPTION
Bug was preventing paste event when no content in the editable content field 
